### PR TITLE
Feature - Add Params For GET calls

### DIFF
--- a/pipedrive/activities.py
+++ b/pipedrive/activities.py
@@ -6,9 +6,9 @@ class Activities(object):
         url = 'activities/{}'.format(activity_id)
         return self._client._get(self._client.BASE_URL + url, **kwargs)
 
-    def get_all_activities(self, **kwargs):
+    def get_all_activities(self, params=None, **kwargs):
         url = 'activities'
-        return self._client._get(self._client.BASE_URL + url, **kwargs)
+        return self._client._get(self._client.BASE_URL + url, params=params, **kwargs)
 
     def create_activity(self, data, **kwargs):
         url = 'activities'
@@ -22,6 +22,6 @@ class Activities(object):
         url = 'activities/{}'.format(activity_id)
         return self._client._delete(self._client.BASE_URL + url, **kwargs)
 
-    def get_activity_fields(self, **kwargs):
+    def get_activity_fields(self, params=None, **kwargs):
         url = 'activityFields'
-        return self._client._get(self._client.BASE_URL + url, **kwargs)
+        return self._client._get(self._client.BASE_URL + url, params=params, **kwargs)

--- a/pipedrive/client.py
+++ b/pipedrive/client.py
@@ -76,8 +76,8 @@ class Client:
     def set_api_token(self, api_token):
         self.api_token = api_token
 
-    def _get(self, url, **kwargs):
-        return self._request('get', url, **kwargs)
+    def _get(self, url, params=None, **kwargs):
+        return self._request('get', url, params=params, **kwargs)
 
     def _post(self, url, **kwargs):
         return self._request('post', url, **kwargs)

--- a/pipedrive/deals.py
+++ b/pipedrive/deals.py
@@ -6,13 +6,13 @@ class Deals(object):
         url = 'deals/{}'.format(deal_id)
         return self._client._get(self._client.BASE_URL + url, **kwargs)
 
-    def get_all_deals(self, **kwargs):
+    def get_all_deals(self, params=None, **kwargs):
         url = 'deals'
-        return self._client._get(self._client.BASE_URL + url, **kwargs)
+        return self._client._get(self._client.BASE_URL + url, params=params, **kwargs)
 
-    def get_all_deals_with_filter(self, filter_id, **kwargs):
+    def get_all_deals_with_filter(self, filter_id, params=None, **kwargs):
         url = 'deals?filter_id={}'.format(filter_id)
-        return self._client._get(self._client.BASE_URL + url, **kwargs)
+        return self._client._get(self._client.BASE_URL + url, params=params, **kwargs)
 
     def create_deal(self, data, **kwargs):
         url = 'deals'
@@ -34,9 +34,9 @@ class Deals(object):
         url = 'deals/{}'.format(deal_id)
         return self._client._get(self._client.BASE_URL + url, **kwargs)
 
-    def get_deals_by_name(self, **kwargs):
+    def get_deals_by_name(self, params=None, **kwargs):
         url = 'deals/find'
-        return self._client._get(self._client.BASE_URL + url, **kwargs)
+        return self._client._get(self._client.BASE_URL + url, params=params, **kwargs)
 
     def get_deal_followers(self, deal_id, **kwargs):
         url = 'deals/{}/followers'.format(deal_id)
@@ -80,9 +80,9 @@ class Deals(object):
         url = 'deals/{}/products'.format(deal_id)
         return self._client._get(self._client.BASE_URL + url, **kwargs)
 
-    def get_deal_fields(self, **kwargs):
+    def get_deal_fields(self, params=None, **kwargs):
         url = 'dealFields'
-        return self._client._get(self._client.BASE_URL + url, **kwargs)
+        return self._client._get(self._client.BASE_URL + url, params=params, **kwargs)
 
     def add_product_to_deal(self, deal_id, data, **kwargs):
         url = 'deals/{}/products'.format(deal_id)

--- a/pipedrive/filters.py
+++ b/pipedrive/filters.py
@@ -6,9 +6,9 @@ class Filters(object):
         url = 'filters/{}'.format(filter_id)
         return self._client._get(self._client.BASE_URL + url, **kwargs)
 
-    def get_all_filters(self, **kwargs):
+    def get_all_filters(self, params=None, **kwargs):
         url = 'filters'
-        return self._client._get(self._client.BASE_URL + url, **kwargs)
+        return self._client._get(self._client.BASE_URL + url, params=params, **kwargs)
 
     def create_filter(self, data, **kwargs):
         url = 'filters'

--- a/pipedrive/notes.py
+++ b/pipedrive/notes.py
@@ -6,9 +6,9 @@ class Notes(object):
         url = 'notes/{}'.format(note_id)
         return self._client._get(self._client.BASE_URL + url, **kwargs)
 
-    def get_all_notes(self, **kwargs):
+    def get_all_notes(self, params=None, **kwargs):
         url = 'notes'
-        return self._client._get(self._client.BASE_URL + url, **kwargs)
+        return self._client._get(self._client.BASE_URL + url, params=params, **kwargs)
 
     def create_note(self, data, **kwargs):
         url = 'notes'
@@ -22,6 +22,6 @@ class Notes(object):
         url = 'notes/{}'.format(note_id)
         return self._client._delete(self._client.BASE_URL + url, **kwargs)
 
-    def get_note_fields(self, **kwargs):
+    def get_note_fields(self, params=None, **kwargs):
         url = 'noteFields'
-        return self._client._get(self._client.BASE_URL + url, **kwargs)
+        return self._client._get(self._client.BASE_URL + url, params=params, **kwargs)

--- a/pipedrive/organizations.py
+++ b/pipedrive/organizations.py
@@ -6,9 +6,9 @@ class Organizations(object):
         url = 'organizations/{}'.format(organization_id)
         return self._client._get(self._client.BASE_URL + url, **kwargs)
 
-    def get_all_organizations(self, **kwargs):
+    def get_all_organizations(self, params=None, **kwargs):
         url = 'organizations'
-        return self._client._get(self._client.BASE_URL + url, **kwargs)
+        return self._client._get(self._client.BASE_URL + url, params=params, **kwargs)
 
     def create_organization(self, data, **kwargs):
         url = 'organizations'
@@ -22,6 +22,6 @@ class Organizations(object):
         url = 'organizations/{}'.format(organization_id)
         return self._client._delete(self._client.BASE_URL + url, **kwargs)
 
-    def get_organization_fields(self, **kwargs):
+    def get_organization_fields(self, params=None, **kwargs):
         url = 'organizationFields'
-        return self._client._get(self._client.BASE_URL + url, **kwargs)
+        return self._client._get(self._client.BASE_URL + url, params=params, **kwargs)

--- a/pipedrive/persons.py
+++ b/pipedrive/persons.py
@@ -6,13 +6,13 @@ class Persons(object):
         url = 'persons/{}'.format(person_id)
         return self._client._get(self._client.BASE_URL + url, **kwargs)
 
-    def get_all_persons(self, **kwargs):
+    def get_all_persons(self, params=None, **kwargs):
         url = 'persons'
-        return self._client._get(self._client.BASE_URL + url, **kwargs)
+        return self._client._get(self._client.BASE_URL + url, params=params, **kwargs)
 
-    def get_persons_by_name(self, **kwargs):
+    def get_persons_by_name(self, params=None, **kwargs):
         url = 'persons/find'
-        return self._client._get(self._client.BASE_URL + url, **kwargs)
+        return self._client._get(self._client.BASE_URL + url, params=params, **kwargs)
 
     def create_person(self, data, **kwargs):
         url = 'persons'
@@ -30,6 +30,6 @@ class Persons(object):
         url = 'persons/{}/deals'.format(person_id)
         return self._client._get(self._client.BASE_URL + url, **kwargs)
 
-    def get_person_fields(self, **kwargs):
+    def get_person_fields(self, params=None, **kwargs):
         url = 'personFields'
-        return self._client._get(self._client.BASE_URL + url, **kwargs)
+        return self._client._get(self._client.BASE_URL + url, params=params, **kwargs)

--- a/pipedrive/recents.py
+++ b/pipedrive/recents.py
@@ -2,6 +2,6 @@ class Recents(object):
     def __init__(self, client):
         self._client = client
 
-    def get_recent_changes(self, **kwargs):
+    def get_recent_changes(self, params=None, **kwargs):
         url = 'recents'
-        return self._client._get(self._client.BASE_URL + url, **kwargs)
+        return self._client._get(self._client.BASE_URL + url, params=params, **kwargs)

--- a/pipedrive/stages.py
+++ b/pipedrive/stages.py
@@ -6,9 +6,9 @@ class Stages(object):
         url = 'stages/{}'.format(stage_id)
         return self._client._get(self._client.BASE_URL + url, **kwargs)
 
-    def get_all_stages(self, **kwargs):
+    def get_all_stages(self, params=None, **kwargs):
         url = 'stages'
-        return self._client._get(self._client.BASE_URL + url, **kwargs)
+        return self._client._get(self._client.BASE_URL + url, params=params, **kwargs)
 
     def get_stage_deals(self, stage_id, **kwargs):
         url = 'stages/{}/deals'.format(stage_id)


### PR DESCRIPTION
Adds `params` to GET calls and adds to most relevant wrapper methods. `params` are added as part of the url query string once it hits the request (passed as a dictionary). This allows for more specific API calls to be made, for example, using a `filter_id` when querying for organizations by filter.

Classes with `params` added to relevant GET calls:
* activities
* deals
* filters
* notes
* organizations
* persons
* recents
* stages